### PR TITLE
Add arpwatch

### DIFF
--- a/arpwatch/arpwatch.go
+++ b/arpwatch/arpwatch.go
@@ -1,0 +1,66 @@
+package arpwatch
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/common/log"
+	junos "github.com/scottdware/go-junos"
+)
+
+const (
+	macsTable = "macs"
+)
+
+type ArpWatch struct {
+	Hosts []string
+	Auth  *junos.AuthMethod
+}
+
+func (a ArpWatch) Update() {
+	redisClient := NewRedisClient()
+	defer redisClient.Close()
+
+	for {
+		select {
+		default:
+
+			for _, h := range a.Hosts {
+				session, err := junos.NewSession(h, a.Auth)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				views, err := session.View("arp")
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				for _, arp := range views.Arp.Entries {
+					result, err := redisClient.SIsMember(macsTable, arp.MACAddress).Result()
+					if err != nil {
+						log.Error(err)
+					}
+
+					if result == false {
+						log.Infof("New MACAddress seen: %+v", arp.MACAddress)
+						_, err := redisClient.SAdd(macsTable, arp.MACAddress).Result()
+						if err != nil {
+							log.Error(err)
+						}
+					}
+
+					keyName := fmt.Sprintf("mac:%s", arp.MACAddress)
+					redisClient.HSet(keyName, "mac", arp.MACAddress)
+					redisClient.HSet(keyName, "ip", arp.IPAddress)
+					redisClient.Expire(keyName, 900*time.Second)
+
+				}
+
+			}
+
+			log.Debugf("Sleeping")
+			time.Sleep(time.Second * 10)
+		}
+	}
+}

--- a/arpwatch/redis.go
+++ b/arpwatch/redis.go
@@ -1,0 +1,13 @@
+package arpwatch
+
+import "github.com/go-redis/redis"
+
+func NewRedisClient() *redis.Client {
+	client := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+
+	return client
+}

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -15,14 +15,24 @@
 package cmd
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
+	"github.com/go-redis/redis"
 	nats "github.com/nats-io/go-nats"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	junos "github.com/scottdware/go-junos"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/xaque208/rftoy/rftoy"
 	"github.com/xaque208/things/things"
+	"github.com/xaque208/znet/arpwatch"
 	"github.com/xaque208/znet/znet"
 )
 
@@ -36,8 +46,83 @@ var listenCmd = &cobra.Command{
 	Run: listen,
 }
 
+var (
+	macAddress = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "mac",
+		Help: "MAC Address",
+	}, []string{"mac", "ip"})
+)
+
+var listenAddr string
+
+const (
+	macsList  = "macs"
+	macsTable = "mac:*"
+)
+
 func init() {
 	rootCmd.AddCommand(listenCmd)
+
+	listenCmd.PersistentFlags().StringVarP(&listenAddr, "listen", "l", ":9100", "Specify listen address")
+
+	prometheus.MustRegister(macAddress)
+}
+
+func listen(cmd *cobra.Command, args []string) {
+	if verbose {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.WarnLevel)
+	}
+
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	messages := make(chan things.Message)
+
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	viper.SetDefault("nats.url", nats.DefaultURL)
+	viper.SetDefault("nats.topic", "things")
+
+	url := viper.GetString("nats.url")
+	topic := viper.GetString("nats.topic")
+
+	log.Debug("Pre-reqs met")
+
+	server, err := things.NewServer(url, topic)
+	if err != nil {
+		log.Error(err)
+	}
+
+	redisClient := arpwatch.NewRedisClient()
+
+	log.Info("Listening to nats")
+	go server.Listen(messages, messageHandler)
+
+	log.Debug("Starting arpwatch")
+	go arpWatch(redisClient)
+
+	log.Debugf("HTTP listening on %s", listenAddr)
+	srv := httpListen(listenAddr)
+
+	go func() {
+		sig := <-sigs
+		log.Warnf("caught signal: %s", sig.String())
+
+		log.Info("Closing thing server")
+		server.Close()
+
+		log.Info("Disconnecting redis")
+		redisClient.Close()
+
+		log.Info("HTTP shutting down")
+		srv.Shutdown(nil)
+
+		done <- true
+	}()
+
+	<-done
+
 }
 
 func lightsHandler(command things.Command) {
@@ -92,26 +177,66 @@ func messageHandler(messages chan things.Message) {
 	}
 }
 
-func listen(cmd *cobra.Command, args []string) {
+func httpListen(listenAddress string) *http.Server {
+	srv := &http.Server{Addr: listenAddress}
 
-	if verbose {
-		log.SetLevel(log.DebugLevel)
-	} else {
-		log.SetLevel(log.WarnLevel)
+	http.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			log.Error(err)
+		}
+	}()
+
+	return srv
+}
+
+func arpWatch(redisClient *redis.Client) {
+
+	hosts := viper.GetStringSlice("junos.hosts")
+	if len(hosts) == 0 {
+		log.Fatal("List of hosts required")
 	}
 
-	viper.SetDefault("nats.url", nats.DefaultURL)
-	viper.SetDefault("nats.topic", "things")
-
-	url := viper.GetString("nats.url")
-	topic := viper.GetString("nats.topic")
-
-	server, err := things.NewServer(url, topic)
-	if err != nil {
-		log.Error(err)
+	auth := &junos.AuthMethod{
+		Username:   viper.GetString("junos.username"),
+		PrivateKey: viper.GetString("junos.keyfile"),
 	}
-	defer server.Close()
 
-	messages := make(chan things.Message)
-	server.Listen(messages, messageHandler)
+	aw := arpwatch.ArpWatch{
+		Hosts: hosts,
+		Auth:  auth,
+	}
+
+	go aw.Update()
+
+	go func() {
+		for {
+			select {
+			default:
+				data, err := redisClient.SMembers(macsList).Result()
+				if err != nil {
+					log.Error(err)
+				}
+
+				for _, i := range data {
+					r, err := redisClient.HGetAll(fmt.Sprintf("mac:%s", i)).Result()
+					if err != nil {
+						log.Error(err)
+					}
+
+					if len(r) == 0 {
+						log.Warnf("Empty data set for %s", i)
+					}
+
+					macAddress.WithLabelValues(r["mac"], r["ip"]).Set(1)
+				}
+
+				// log.Debugf("Sleeping %d seconds", 30)
+				time.Sleep(time.Second * 30)
+			}
+		}
+
+	}()
+
 }


### PR DESCRIPTION
Here started a separate command, but is now worked into the listen command.
Asks juniper devices for their arp entries and writes info to redis.  The
listener picks up the messages from redis and sets prometheus values available
over /metrics on 9100 by default.